### PR TITLE
Fix for pyflakes 2.5+ which removes some python 2 specific errors

### DIFF
--- a/pyqode/python/backend/workers.py
+++ b/pyqode/python/backend/workers.py
@@ -214,12 +214,14 @@ def run_pep8(request_data):
 
 
 PYFLAKES_ERROR_MESSAGES = [
-    messages.DoctestSyntaxError,
-    messages.ReturnWithArgsInsideGenerator,
-    messages.UndefinedExport,
-    messages.UndefinedName,
-    messages.UndefinedLocal
+    'DoctestSyntaxError',
+    'ReturnWithArgsInsideGenerator',
+    'UndefinedExport',
+    'UndefinedName',
+    'UndefinedLocal'
 ]
+PYFLAKES_ERROR_MESSAGES = [getattr(messages, x) for x in \
+                           PYFLAKES_ERROR_MESSAGES if hasattr(messages, x)]
 
 
 def run_pyflakes(request_data):


### PR DESCRIPTION
pyflakes 2.5+ removes some of the error message classes that were only used by python 2. This is making pyqode throw an exception because ReturnWithArgsInsideGenerator no longer exists. I edited the creation of the PYFLAKES_ERROR_MESSAGES list so it checks if those messages exist when making the list. This works for both old versions of pyflakes and 2.5+.